### PR TITLE
bugfix std::to_string changed to C++98 compatible function

### DIFF
--- a/inc/TCPServer.hpp
+++ b/inc/TCPServer.hpp
@@ -16,10 +16,14 @@
 #include <csignal>
 #include <cstdlib>
 #include <netdb.h>
+#include <sstream>
 
 #include "Request.hpp"
 #include "Configuration.hpp"
 #include "webserv.hpp"
+
+#define SSTR( x ) static_cast< std::ostringstream & >( \
+        ( std::ostringstream() << std::dec << x ) ).str()
 
 extern bool sigint_flag;
 

--- a/src/TCPServer.cpp
+++ b/src/TCPServer.cpp
@@ -29,7 +29,7 @@ TCPServer::TCPServer(Configuration& config) : _timeout(3 * 60 * 1000), _client_s
             int yes = 1;
             int status;
 
-            std::string port = std::to_string(config_info.getListen(j));
+            std::string port = SSTR(config_info.getListen(j));
 
             std::cout << "Server " << i << ": Host: " << host << ", Port: " << port << std::endl;
             struct addrinfo hints;


### PR DESCRIPTION
I changed std::to_string C++11 function to Macro

#include <sstream>

#define SSTR( x ) static_cast< std::ostringstream & >( \
        ( std::ostringstream() << std::dec << x ) ).str()

see https://stackoverflow.com/questions/5590381/how-to-convert-int-to-string-in-c

Hope it compiles now on school machines. On my mac it compiles.